### PR TITLE
Depend on numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
 ]
 urls = {Homepage = "https://github.com/trimesh/openctm"}
 
+dependencies = ["numpy"]
+
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"


### PR DESCRIPTION
Since this package requires `numpy`,

https://github.com/trimesh/openctm/blob/e57d663d0fe2215845d5de8314db8c68ba174a90/openctm/binding.py#L35

it should depend on it directly.